### PR TITLE
fix: default server URLs to empty string if None

### DIFF
--- a/dashboard_api/core/config.py
+++ b/dashboard_api/core/config.py
@@ -10,7 +10,11 @@ config_object = yaml.load(
 
 STAGE = os.environ.get("STAGE", config_object["STAGE"])
 VECTOR_TILESERVER_URL = os.environ.get("VECTOR_TILESERVER_URL", config_object["VECTOR_TILESERVER_URL"])
+if VECTOR_TILESERVER_URL is None:
+    VECTOR_TILESERVER_URL = ""
 TITILER_SERVER_URL = os.environ.get("TITILER_SERVER_URL", config_object["TITILER_SERVER_URL"])
+if TITILER_SERVER_URL is None:
+    TITILER_SERVER_URL = ""
 API_VERSION_STR = "/v1"
 
 PROJECT_NAME = config_object["PROJECT_NAME"]


### PR DESCRIPTION
For whatever reason, the empty string value defined in the yaml config is getting converted to a value of None for the key, so we explicitly set it to the empty string when that's the case.