### PR TITLE
add github action deploy performance improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,10 +44,37 @@ jobs:
         with:
           node-version: '14'
 
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('package.json') }} # or package-lock.json
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Upgrade pip
+        run: sudo python -m pip install -U pip
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install jq
         run: sudo apt-get install jq
 
-      - name: Install AWS CDK, pip requirements and run CDK bootstrap
+      - name: Install AWS CDK and pip requirements
         run: ./install.sh
 
       - name: Deploy the resources to AWS

--- a/Dockerfiles/lambda/Dockerfile
+++ b/Dockerfiles/lambda/Dockerfile
@@ -1,30 +1,28 @@
 FROM lambci/lambda:build-python3.7
+# or, if choosing to use a container pre-built with numpy:
+# FROM AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/PROJECT-dashboard-api-base:TAG
 
-
-# We install dashboard_api and mangum
 WORKDIR /app
 
 COPY README.md /app/README.md
 COPY dashboard_api/ /app/dashboard_api/
 COPY setup.py /app/setup.py
 
-RUN pip install --upgrade pip
-RUN pip install . "mangum>=0.9.0,<0.10.1" -t /var/task --no-binary numpy, pydantic
-
-# Reduce package size and remove useless files
-RUN cd /var/task && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
-RUN cd /var/task && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-RUN cd /var/task && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
-RUN find /var/task -type d -a -name 'tests' -print0 | xargs -0 rm -rf
-RUN echo "Remove lambda python packages"
-RUN rm -rdf /var/task/numpy/doc/ 
-RUN rm -rdf /var/task/stack
-RUN rm -rdf /var/task/boto3*
-RUN rm -rdf /var/task/botocore*
-RUN rm -rdf /var/task/docutils*
-RUN rm -rdf /var/task/dateutil*
-RUN rm -rdf /var/task/jmespath*
-RUN rm -rdf /var/task/s3transfer*
+RUN pip install --upgrade pip && \
+    pip install . "mangum>=0.9.0,<0.10.1" -t /var/task --no-binary numpy,pydantic && \
+    cd /var/task && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done; \
+    cd /var/task && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf && \
+    cd /var/task && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f && \
+    find /var/task -type d -a -name 'tests' -print0 | xargs -0 rm -rf && \
+    echo "Remove lambda python packages" && \
+    rm -rdf /var/task/numpy/doc/  && \
+    rm -rdf /var/task/stack && \
+    rm -rdf /var/task/boto3* && \
+    rm -rdf /var/task/botocore* && \
+    rm -rdf /var/task/docutils* && \
+    rm -rdf /var/task/dateutil* && \
+    rm -rdf /var/task/jmespath* && \
+    rm -rdf /var/task/s3transfer*
 
 RUN mkdir /var/task/stack
 COPY stack/config.yml /var/task/stack/config.yml

--- a/Dockerfiles/lambda/Dockerfile.base
+++ b/Dockerfiles/lambda/Dockerfile.base
@@ -1,0 +1,7 @@
+FROM lambci/lambda:build-python3.7
+
+WORKDIR /app
+
+RUN pip install --upgrade pip && \
+    pip install "numpy~=1.21.0" "rio-tiler==2.0a.11" geojson-pydantic python-binary-memcached rio-toa uhashring \
+     -t /var/task --no-binary numpy,pydantic 

--- a/Dockerfiles/lambda/Makefile
+++ b/Dockerfiles/lambda/Makefile
@@ -1,0 +1,25 @@
+.phony: all
+
+all: docker-build docker-push
+
+IMG_NAME = PROJECT-dashboard-api-base
+$(eval AWS_ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output text))
+$(eval GIT_REV=$(shell git rev-parse HEAD | cut -c1-7))
+$(eval DT=$(shell date -u +"%Y-%m-%d-%H-%M-%S"))
+REV = $(GIT_REV)-$(DT)
+$(eval REG=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com)
+$(eval REPO=$(REG)/$(IMG_NAME))
+
+# Login to ECR
+ecr-login:
+	aws ecr get-login-password --region $(AWS_REGION) | docker login --password-stdin --username AWS $(REG)
+
+# Build and tag docker image
+docker-build:
+	docker build -f Dockerfile.base --no-cache -t $(IMG_NAME) .
+
+# Push docker image
+# Don't push latest, as this can only be pushed once in an immutable ECR repo
+docker-push: ecr-login
+	docker tag $(IMG_NAME):latest $(REPO):$(REV)
+	docker push $(REPO):$(REV)

--- a/README.md
+++ b/README.md
@@ -57,14 +57,36 @@ Issues and pull requests are more than welcome.
 
 Metadata is used to list serve data via `/datasets`, `/tiles`, and `/timelapse`. Datasets are fetched from the bucket configured in `config.yml`. When using github actions to deploy the API this config file is generated from `stack/config.yml.example` using the variables (including a bucket) defined there. Assuming you are using the API with a repo based off of https://github.com/NASA-IMPACT/dashboard-datasets-starter/, you will want to configure `DATA_BUCKET` in deploy.yml to match what is deployed as a part of your datasets.repo.
 
-## Cloud Deployment
+## Automated Cloud Deployment via GitHub Actions
 
-Requirements:
+The file `.github/workflows/deploy.yml` describes how to deploy this service from GitHub Actions, and will
+automatically try to do so. This requires a few secrets to be configured.  This deployment method is documented 
+in greater detail [here](https://github.com/NASA-IMPACT/earthdata-dashboard-starter/wiki/Create-Your-Own-Dashboard).
+
+### Build and deploy performance improvement with GitHub Actions (Optional, but recommended) 
+
+By default, this service deploys using GitHub Actions. One limitation of GitHub Actions is the lack of a fast
+and easy way to persist Docker image layers between executions. This means that each build starts with an empty
+Docker layer cache. This is a particular problem for this build, as it requires several packages, notably numpy, 
+to be built from source because binary packages for the lambda environment do not exist. This can take up to 
+10 minutes. The way to get around this is to pre-build a Docker image with numpy from the lambda base image and use
+this in the CI build.
+
+1. Edit `Dockerfiles/lambda/Makefile` and replace the value of `IMG_NAME = PROJECT-dashboard-api-base` the the name of this project, e.g., `IMG_NAME = myproject-dashboard-api-base`
+2. Create an ECR Repository with the name used for `IMG_NAME`, e.g., `aws ecr create-repository --repository-name myproject-dashboard-api-base --image-tag-mutability IMMUTABLE`
+3. In directory `Dockerfiles/lambda`, run `make`. This should publish a new base image to the ECR repository.
+4. Edit the `FROM` directive in `Dockerfiles/lambda/Dockerfile` to reference the new image in ECR.
+5. Edit `deploy.sh` and uncomment the line that performs ECR login.
+6. Commit all of these changes to GitHub and continue with the remaining configuration steps.
+
+## Manual Cloud Deployment
+
+### Requirements
 
 * npm
 * jq
 
-### Install AWS CDK, pip requirements and run CDK bootstrap
+### Install AWS CDK and pip requirements 
 
 `./install.sh` should only be run once and if requirements set in `setup.py` change.
 
@@ -76,12 +98,28 @@ export AWS_PROFILE=CHANGEME
 ./install.sh
 ```
 
+### Run CDK bootstrap
+
+The CDK bootstrap command installs resources necessary to use CDK in your AWS account.
+
+```bash
+export AWS_PROFILE=CHANGEME
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --profile github-deploy | jq .Account -r)
+export AWS_REGION=$(aws configure get region)
+cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_REGION --all
+```
+
+### Deploy
+
 Deploy the app!
 
 This currently deploys 2 stacks.
 
 ```bash
 export AWS_PROFILE=CHANGEME
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq .Account -r)
+export AWS_REGION=$(aws configure get region)
+
 # Note - the docker build is currently slow so this can take 5+ minutes to run 
 ./deploy.sh
 ```

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-export AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq .Account -r)
-export AWS_REGION=$(aws configure get region)
+
+# uncomment this line if using an image with numpy already installed from ECR
+# aws ecr get-login-password --region ${AWS_REGION} | docker login --password-stdin --username AWS ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+
 cdk deploy --all --require-approval never

--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,3 @@ npm install -g aws-cdk
 # Note: zsh users need to use ""
 echo "Installing python packages (pip)"
 pip install -e ".[deploy]"
-
-# echo "Setting AWS_ACCOUNT_ID and AWS_REGION"
-# # Bootstrap the AWS accont
-# export AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq .Account -r)
-# export AWS_REGION=$(aws configure get region)
-
-echo "CDK bootstrapping AWS_ACCOUNT_ID and AWS_REGION"
-cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_REGION --all

--- a/stack/app.py
+++ b/stack/app.py
@@ -165,7 +165,7 @@ class dashboardApiLambdaStack(core.Stack):
         return aws_lambda.Code.from_asset(
             path=os.path.abspath(code_dir),
             bundling=core.BundlingOptions(
-                image=core.BundlingDockerImage.from_asset(
+                image=core.DockerImage.from_build(
                     path=os.path.abspath(code_dir),
                     file="Dockerfiles/lambda/Dockerfile",
                 ),


### PR DESCRIPTION
By default, deploy takes about 15 minutes, with about 10 minutes of that spent compiling numpy and a few other packages. 

This adds alternate code and a description of how to use it that creates a docker image with these packages already installed, so the build only takes a couple minutes and the deploy to AWS another 3-5 minutes. I set it up as an alternate configuration so that someone could avoid doing the ECR setup, etc, if they didn't care that it takes so long to build or if they were using a different CI like CircleCI (which has an easy-to-use Docker caching system built-in). 

I'll make these changes in dashboard-api-maap too.